### PR TITLE
More convenient useage of Python3.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,18 @@ Common sense, the first is the right answer.
 
 #### Install
 
+**NB:** `PyKoSpacing` depends on `keras` which only supports `python==3.6.x`. Using [Anaconda](https://www.anaconda.com/) to install 'PyKoSpacing' will prevent interference with system-wide python packages.
+
+##### Anaconda Install
+```
+conda create --name py-kospacing python=3.6 --yes
+conda activate py-kospacing
+conda install keras=2.1.5 h5py=2.7.1 --yes
+pip install tensorflow==1.6.0 argparse">=1.4.0"
+pip install git+https://github.com/haven-jeon/PyKoSpacing.git
+```
+
+##### PyPI Install
 Pre-requisite:
 ```
   proper installation of python3

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@ from pykospacing import __version__
 
 
 setup(name='pykospacing',
+      python_requires='==3.6.*',
       version=__version__,
       url='https://github.com/haven-jeon/PyKoSpacing',
       license='GPL-3',


### PR DESCRIPTION
2020다 되니까 python37이나 python38의 환경 보존 하기위해서 [`KoSpacing`](https://github.com/haven-jeon/KoSpacing)처럼 anaconda로 설치 하면 더 좋을것 같아서, 그 내용을 설치 앞부분에 넣어 봤습니다. 또는 사용자가 python37이나 python38으로 설치하면 `setup.py`가 분명이 오류를 만들게 했습니다.