### PR TITLE
Fix : Hide warning messages when using pykospacing

### DIFF
--- a/pykospacing/kospacing.py
+++ b/pykospacing/kospacing.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import os
+os.environ['TF_CPP_MIN_LOG_LEVEL'] = '3'
 import re
 import csv
 
@@ -9,7 +10,7 @@ from tensorflow.keras.models import load_model
 from pykospacing.embedding_maker import encoding_and_padding, load_vocab
 
 __all__ = ['Spacing', ]
-os.environ['TF_CPP_MIN_LOG_LEVEL'] = '2'
+
 
 model_path = pkg_resources.resource_filename(
     'pykospacing', os.path.join('resources', 'models', 'kospacing'))


### PR DESCRIPTION
# Issue

pykospacing 을 쓰면 warning messages 가 너무 많이 나와 가독성이 떨어지는 이슈가 있었습니다.

## Solution

`os.environ['TF_CPP_MIN_LOG_LEVEL'] = '3'` 을 `os` 를 import 하자마자 설정해주어야 제대로 작동하는 것을 확인했습니다!


## Changes

### `변경 전`
![image](https://user-images.githubusercontent.com/54366260/170682016-0403fce8-ea19-4b0c-a4c3-e3b7a9eb52ff.png)

### `변경 후`
![image](https://user-images.githubusercontent.com/54366260/170682114-9fa03ed8-2594-4e01-b07d-ab750c8e2fab.png)

