### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,8 +15,8 @@ setup(name='pykospacing',
       include_package_data=True,
 
       install_requires=[
-          'tensorflow == 2.7.2',
-          'h5py == 3.1.0',
+          'tensorflow >= 2.7.2',
+          'h5py >= 3.1.0',
           'argparse >= 1.4.0',
       ],
 


### PR DESCRIPTION
아치 리눅스 환경에서 파이선 3.10.5 64비트 주피터 노트북 환경을 통하여 pip 설치를 시도하였으나 의존성 문제로 설치에 문제가 생겨 임의로 다음 리퀘스트와 같이 변경한뒤 실행하니 예제코드에 한해서는 문제없이 작동하고 있었습니다. 
아무래도 pip 를 통한 텐서플로우 2.7.2 버전이 구 버전으로 들어가면서 설치에 문제가 발생한 것으로 보이는데 이에 관련하여 확인 부탁드리고자 풀 리퀘스트 남기고 갑니다.  