### PR TITLE
#47-debugging-for-m1

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,22 @@ On error: /usr/lib/x86_64-linux-gnu/libstdc++.so.6: version `GLIBCXX_3.4.22' not
    sudo apt-get upgrade
    sudo apt-get dist-upgrade (This takes long time.)
 ```     
+Darwin(m1) case: You should install tensorflow in a different way.(Use [Miniforge3](https://github.com/conda-forge/miniforge))
+```sh
+# Install Miniforge3 for mac
+curl -O https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-MacOSX-arm64.sh
+chmod +x Miniforge3-MacOSX-arm64.sh
+sh Miniforge3-MacOSX-arm64.sh
+# Activate Miniforge3 virtualenv
+# You should use Python version 3.10 or less.
+source ~/miniforge3/bin/activate
+# Install the Tensorflow dependencies 
+conda install -c apple tensorflow-deps 
+# Install base tensorflow 
+python -m pip install tensorflow-macos 
+# Install metal plugin 
+python -m pip install tensorflow-metal
+```
 
 To install from GitHub, use
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 tensorflow == 2.9.3
 h5py == 3.1.0
+argparse >= 1.4.0

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,15 @@
 from setuptools import setup
+import os, platform
 
+def requirements():
+    if platform.system() == 'Darwin':
+        return []
+
+    def open_req(req_file):
+        with open(os.path.join(os.path.dirname(os.path.abspath("__file__")), req_file)) as f:
+            return f.read().splitlines()
+
+    return open_req('requirements.txt')
 
 setup(name='pykospacing',
       python_requires='>=3.6',
@@ -14,11 +24,7 @@ setup(name='pykospacing',
       zip_safe=False,
       include_package_data=True,
 
-      install_requires=[
-          'tensorflow == 2.9.3',
-          'h5py == 3.1.0',
-          'argparse >= 1.4.0',
-      ],
+      install_requires=requirements(),
 
       entry_points={
           'console_scripts': [


### PR DESCRIPTION
#47 에서 있었던 오류 해결
- m1(Darwin)인 경우 requirements.txt가 아닌 return []으로 처리
- 그 외 os들은 기존 requirements.txt와 동일하게 유지

해당 코드를 실행하면 m1에서 설치 가능


그러나 실제 아래 코드 실행 시에

```
from pykospacing import Spacing
```
numpy, tensorflow 등을 설치하라는 내용이 발생함.
그런 경우에는 m1에 필요한 tensorflow 등을 설치하면 정상적으로 실행가능. 
m1 용 tensorflow 설치 방법은 [해당 사이트](https://jongsky.tistory.com/34)를 참고.
